### PR TITLE
Corrected link to the pgRouting gallery in the github wiki

### DIFF
--- a/gallery.rst
+++ b/gallery.rst
@@ -14,7 +14,7 @@ pgRouting Gallery
 
 The gallery can be found here:
 
-* https://github.com/pgRouting/pgrouting/wiki/Using-pgRouting
+* https://github.com/pgRouting/pgrouting/wiki/Gallery
 
 .. note::
 


### PR DESCRIPTION
Fixes #94 

Changes proposed in this pull request:
- Fixes link to pgRouting gallery

@pgRouting/admins
