### PR TITLE
Update project leadership with new PSC members.

### DIFF
--- a/development.rst
+++ b/development.rst
@@ -38,7 +38,7 @@ Current members of the the Project Steering Committee are:
 
   * OSGeo Charter member since 2015
   * Co-leader of pgRouting Docker
-  * Co-leader of osm2pgRouting
+  * Co-leader of pgRoutingLayer
 
 * Rajat Shinde
 

--- a/development.rst
+++ b/development.rst
@@ -19,15 +19,7 @@ Current members of the the Project Steering Committee are:
   * OSGeo Charter member since 2021
   * Ex-Google summer of code student
   * Google summer of code mentor and administrator
-  * Leader of vrpRouting (vrp = vehicle routing problems)
-
-* Cayetano Benavent
-
-  * OSGeo Charter member since 2018
-  * Google summer of code mentor
-  * Leader of pgRouting Docker
-  * Leader of pgRoutingLayer
-  * Co-leader of osm2pgRouting
+  * Co-leader of vrpRouting (vrp = vehicle routing problems)
 
 * Daniel Kastl
 
@@ -35,6 +27,18 @@ Current members of the the Project Steering Committee are:
   * Google summer of code mentor
   * Founder of pgRouting organization
   * In charge of financial affairs
+
+* Iosefa Percival
+
+  * Google summer of code mentor
+  * Co-leader of pgRouting Docker
+  * Co-leader of vrpRouting
+
+* Ko Nagase
+
+  * OSGeo Charter member since 2015
+  * Co-leader of pgRouting Docker
+  * Co-leader of osm2pgRouting
 
 * Rajat Shinde
 


### PR DESCRIPTION
Redistributed contributor roles for clarity and consistency. Updated leadership information for pgRouting-related projects and added new contributors with their respective roles.

Changes proposed in this pull request:
- updates PSC on website

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated Project Steering Committee membership
	- Added two new members: Iosefa Percival and Ko Nagase
	- Removed Cayetano Benavent from the committee
	- Adjusted leadership role for vrpRouting project from Leader to Co-leader
<!-- end of auto-generated comment: release notes by coderabbit.ai -->